### PR TITLE
(innosetup) Fix detection of new version

### DIFF
--- a/automatic/innosetup/update.ps1
+++ b/automatic/innosetup/update.ps1
@@ -38,7 +38,7 @@ function global:au_GetLatest {
 
   $download_page = Invoke-WebRequest -UseBasicParsing -Uri ($versionDirUrl + $versionReleaseDir)
   $re    = 'innosetup.*unicode\.exe'
-  $file   = $download_page.links | ? href -match $re | select -First 1 -expand href
+  $file   = $download_page.links | ? href -match $re | select -Last 1 -expand href
   $url = ($versionDirUrl + $versionReleaseDir + $file)
 
   $version  = $url -split '[_-]|.exe' | select -Last 1 -Skip 2


### PR DESCRIPTION
Up until just recently, there was only one version of innosetup which matched the regex. Now there are two new versions, so the last instead of the first one should be picked (similar to $versionReleaseDir).