### PR TITLE
Use the cloud mirror for all CRAN links

### DIFF
--- a/automatic/r.project/legal/VERIFICATION.txt
+++ b/automatic/r.project/legal/VERIFICATION.txt
@@ -2,10 +2,10 @@ VERIFICATION
 Verification is intended to assist the Chocolatey moderators and community
 in verifying that this package's contents are trustworthy.
 
-The installer have been downloaded from their official download link listed on <https://cran.r-project.org/bin/windows/base/>
+The installer have been downloaded from their official download link listed on <https://cloud.r-project.org/bin/windows/base/>
 and can be verified like this:
 
-1. Download <https://cran.r-project.org/bin/windows/base/R-3.6.1-win.exe>
+1. Download <https://cloud.r-project.org/bin/windows/base/R-3.6.1-win.exe>
 2. Then use one of the following methods to obtain the checksum
   - Use powershell function 'Get-Filehash'
   - Use chocolatey utility 'checksum.exe'

--- a/automatic/r.project/r.project.nuspec
+++ b/automatic/r.project/r.project.nuspec
@@ -13,7 +13,7 @@
     <licenseUrl>http://www.r-project.org/Licenses/</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <projectSourceUrl>https://svn.r-project.org/R/</projectSourceUrl>
-    <docsUrl>https://cran.r-project.org/manuals.html</docsUrl>
+    <docsUrl>https://cloud.r-project.org/manuals.html</docsUrl>
     <mailingListUrl>https://www.r-project.org/mail.html</mailingListUrl>
     <bugTrackerUrl>https://bugs.r-project.org/bugzilla3/</bugTrackerUrl>
     <tags>r r-project r-base admin statistics programming data-analysis programming-language mathematics data-mining
@@ -55,7 +55,7 @@ R has its own LaTeX-like documentation format, which is used to supply comprehen
 `choco install r.project --params "'/UseInf:C:\r.project.inf'"`
 ]]></description>
     <releaseNotes>
-[Software Changelog](https://cran.r-project.org/doc/manuals/r-release/NEWS.html)
+[Software Changelog](https://cloud.r-project.org/doc/manuals/r-release/NEWS.html)
 [Package Changelog](https://github.com/AdmiringWorm/chocolatey-packages/blob/master/automatic/r.project/Changelog.md)
     </releaseNotes>
   </metadata>

--- a/automatic/r/r.nuspec
+++ b/automatic/r/r.nuspec
@@ -13,7 +13,7 @@
     <licenseUrl>http://www.r-project.org/Licenses/</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <projectSourceUrl>https://svn.r-project.org/R/</projectSourceUrl>
-    <docsUrl>https://cran.r-project.org/manuals.html</docsUrl>
+    <docsUrl>https://cloud.r-project.org/manuals.html</docsUrl>
     <mailingListUrl>https://www.r-project.org/mail.html</mailingListUrl>
     <bugTrackerUrl>https://bugs.r-project.org/bugzilla3/</bugTrackerUrl>
     <tags>r r-project r-base admin statistics programming data-analysis programming-language mathematics data-mining
@@ -55,7 +55,7 @@ R has its own LaTeX-like documentation format, which is used to supply comprehen
 `choco install r --params "'/UseInf:C:\r.inf'"`
 ]]></description>
     <releaseNotes>
-[Software Changelog](https://cran.r-project.org/doc/manuals/r-release/NEWS.html)
+[Software Changelog](https://cloud.r-project.org/doc/manuals/r-release/NEWS.html)
 [Package Changelog](https://github.com/AdmiringWorm/chocolatey-packages/blob/master/automatic/r.project/Changelog.md)
     </releaseNotes>
     <dependencies>

--- a/automatic/r/update.ps1
+++ b/automatic/r/update.ps1
@@ -1,6 +1,6 @@
 ﻿import-module au
 
-$releases = 'https://cran.r-project.org/bin/windows/base/'
+$releases = 'https://cloud.r-project.org/bin/windows/base/'
 
 function global:au_SearchReplace {
   @{


### PR DESCRIPTION
The cloud mirror generally has better throughput and response times than
the main site and using it also reduces the load on the main CRAN servers.