### PR TITLE
Add new package "qtcreatorcdbext" for Qt Creator's CDB Extension

### DIFF
--- a/automatic/qtcreator-cdbext/Changelog.md
+++ b/automatic/qtcreator-cdbext/Changelog.md
@@ -1,0 +1,5 @@
+# ![Qt Creator CDB Extension Changelog](https://img.shields.io/badge/Qt%20Creator%20CDB%20Extension-Package%20Changelog-blue.svg?style=for-the-badge)
+
+## UPCOMING
+
+- Initial implementation of the qtcreator-cdbext chocolatey package

--- a/automatic/qtcreator-cdbext/Readme.md
+++ b/automatic/qtcreator-cdbext/Readme.md
@@ -1,0 +1,5 @@
+# [<img src="https://cdn.jsdelivr.net/gh/AdmiringWorm/chocolatey-packages@35eb3e49edb3411d779f64e57ef023abac8a3a06/icons/qtcreator.png" height="48" width="48" /> ![Qt Creator CDB Extension](https://img.shields.io/chocolatey/v/qtcreator-cdbext.svg?label=Qt%20Creator%20CDB%20Extension&style=for-the-badge)](https://chocolatey.org/packages/qtcreator-cdbext)
+
+Qt Creator CDB Extension adds support for the Microsoft Console Debugger (CDB) to Qt Creator, a cross-platform, complete integrated development environment (IDE) for application developers to create applications for multiple desktop and mobile device platforms, such as Android and iOS.
+
+The Debugging Tools for Windows (which include the CDB debugger) need to be installed separately by installing one of the components mentioned on [this Microsoft help page](https://docs.microsoft.com/en-us/windows-hardware/drivers/debugger/). (Chocolatey packages for different versions of the components are available.)

--- a/automatic/qtcreator-cdbext/qtcreator-cdbext.nuspec
+++ b/automatic/qtcreator-cdbext/qtcreator-cdbext.nuspec
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Do not remove this test for UTF-8: if “Ω” doesn’t appear as greek uppercase omega letter enclosed in quotation marks, you should use an editor that supports UTF-8, not this one. -->
+<package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
+  <metadata>
+    <id>qtcreator-cdbext</id>
+    <version>0.0</version>
+    <packageSourceUrl>https://github.com/admiringworm/chocolatey-packages/tree/master/automatic/qtcreator-cdbext</packageSourceUrl>
+    <owners>AdmiringWorm, michaelweghorn</owners>
+    <title>Qt Creator CDB Extension</title>
+    <authors>Qt Project</authors>
+    <projectUrl>http://wiki.qt.io/Qt_Creator</projectUrl>
+    <iconUrl>https://cdn.jsdelivr.net/gh/AdmiringWorm/chocolatey-packages@35eb3e49edb3411d779f64e57ef023abac8a3a06/icons/qtcreator.png</iconUrl>
+    <copyright>© 2020 The Qt Company Ltd.</copyright>
+    <licenseUrl>http://code.qt.io/cgit/qt-creator/qt-creator.git/plain/LICENSE.GPL3-EXCEPT?h=4.1</licenseUrl>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <projectSourceUrl>https://code.qt.io/cgit/qt-creator/qt-creator.git/tree/src/libs/qtcreatorcdbext/</projectSourceUrl>
+    <docsUrl>https://wiki.qt.io/Qt_Creator_Windows_Debugging</docsUrl>
+    <mailingListUrl>http://lists.qt-project.org/mailman/listinfo/qt-creator/</mailingListUrl>
+    <bugTrackerUrl>https://bugreports.qt.io/browse/QTCREATORBUG</bugTrackerUrl>
+    <tags>c++ qt ide qtcreator qtcreatorcdbext plugin</tags>
+    <summary>CDB (Microsoft Console Debugger) extension for Qt Creator.</summary>
+    <!-- Do not touch the description here in the nuspec file. Description is imported during update from the Readme.md file -->
+    <description><![CDATA[Qt Creator CDB Extension adds support for the Microsoft Console Debugger (CDB) to Qt Creator, a cross-platform, complete integrated development environment (IDE) for application developers to create applications for multiple desktop and mobile device platforms, such as Android and iOS.
+
+The Debugging Tools for Windows (which include the CDB debugger) need to be installed separately by installing one of the components mentioned on [this Microsoft help page](https://docs.microsoft.com/en-us/windows-hardware/drivers/debugger/). (Chocolatey packages for different versions of the components are available.)
+]]></description>
+    <releaseNotes>[Software Changelog](http://code.qt.io/cgit/qt-creator/qt-creator.git/plain/dist/changes-4.13.2.md)
+[Package Changelog](https://github.com/AdmiringWorm/chocolatey-packages/blob/master/automatic/qtcreator-cdbext/Changelog.md)</releaseNotes>
+    <dependencies>
+      <dependency id="qtcreator" version="[4.13.2]" />
+    </dependencies>
+  </metadata>
+  <files>
+    <file src="tools\**" target="tools" />
+  </files>
+</package>

--- a/automatic/qtcreator-cdbext/tools/chocolateyinstall.ps1
+++ b/automatic/qtcreator-cdbext/tools/chocolateyinstall.ps1
@@ -1,0 +1,17 @@
+﻿$ErrorActionPreference = 'Stop'
+
+$installToolsPath = Get-ToolsLocation
+
+$packageArgs = @{
+  packageName    = $env:ChocolateyPackageName
+  url            = 'https://download.qt.io/official_releases/qtcreator/4.13/4.13.2/installer_source/windows_x86/qtcreatorcdbext.7z'
+  url64bit       = 'https://download.qt.io/official_releases/qtcreator/4.13/4.13.2/installer_source/windows_x64/qtcreatorcdbext.7z'
+  destination    = "$installToolsPath\qtcreator"
+  checksum       = '45f0103f3a5946ef61e828dac346699e54a30d9f6671a3eb7bb0b9a8777910c1'
+  checksumType   = 'sha256'
+  checksum64     = 'bd096cc7278b5229787966b45d55409301c8e2c4771080e26737c72ef5b10be7'
+  checksumType64 = 'sha256'
+
+}
+
+Install-ChocolateyZipPackage @packageArgs

--- a/automatic/qtcreator-cdbext/update.ps1
+++ b/automatic/qtcreator-cdbext/update.ps1
@@ -1,0 +1,55 @@
+﻿Import-Module AU
+
+$releases = 'https://www1.qt.io/offline-installers/'
+
+function global:au_SearchReplace {
+  @{
+    ".\$($Latest.PackageName).nuspec" = @{
+      "(\<dependency .+?`"qtcreator`" version=)`"([^`"]+)`"" = "`$1`"[$($Latest.Version)]`""
+    }
+    ".\tools\chocolateyInstall.ps1" = @{
+      "(?i)^(\s*url\s*=\s*)'.*'"            = "`${1}'$($Latest.URL32)'"
+      "(?i)^(\s*url64(bit)?\s*=\s*)'.*'"    = "`${1}'$($Latest.URL64)'"
+      "(?i)^(\s*checksum\s*=\s*)'.*'"       = "`${1}'$($Latest.Checksum32)'"
+      "(?i)^(\s*checksumType\s*=\s*)'.*'"   = "`${1}'$($Latest.ChecksumType32)'"
+      "(?i)^(\s*checksum64\s*=\s*)'.*'"     = "`${1}'$($Latest.Checksum64)'"
+      "(?i)^(\s*checksumType64\s*=\s*)'.*'" = "`${1}'$($Latest.ChecksumType64)'"
+    }
+  }
+}
+
+function global:au_AfterUpdate {
+  Update-Changelog -useIssueTitle
+
+  $releaseNotes = @"
+[Software Changelog](http://code.qt.io/cgit/qt-creator/qt-creator.git/plain/dist/changes-$($Latest.RemoteVersion).md)
+[Package Changelog](https://github.com/AdmiringWorm/chocolatey-packages/blob/master/automatic/qtcreator-cdbext/Changelog.md)
+"@
+
+  Update-Metadata -key "releaseNotes" -value $releaseNotes
+}
+
+function global:au_GetLatest {
+  $download_page = Invoke-WebRequest -Uri $releases -UseBasicParsing
+
+  $re = 'qt-creator.*x86\-.*\.exe'
+  $versionURL = $download_page.Links | ? href -match $re | select -first 1 -expand href
+
+  $version = $versionURL -split '\/' | select -last 1 -skip 1
+  $versionTwoPart = $version -replace "^(\d+\.\d+).*", '$1'
+
+  $url = "https://download.qt.io/official_releases/qtcreator/$versionTwoPart/$version/installer_source/"
+  $download_page = Invoke-WebRequest -Uri $url -UseBasicParsing
+  $links = $download_page.links | ? href -match '^windows' | select -expand href
+  $url32 = ($links -match '(x86|_32)\/$' | select -first 1 | % { $url + $_ }) + "qtcreatorcdbext.7z"
+  $url64 = ($links -match '[x_]64\/$' | select -first 1 | % { $url + $_ }) + "qtcreatorcdbext.7z"
+
+  return @{
+    URL32         = $url32
+    URL64         = $url64
+    Version       = $version
+    RemoteVersion = $version
+  }
+}
+
+update


### PR DESCRIPTION
This adds the CDB debugger extension for Qt Creator. As discussed in #216, a new package is created rather than addint it into the existing `qtcreator` package.

The packaging files were created based on the ones for the 'qtcreator' package, i.e. those for the existing 'qtcreator' package  were initially copied, then adapted for this new package as needed.

Fixes: #216

Note: I've created this for Qt Creator 4.13.2 already, which is currently only available on the `master` branch, not `develop` yet, so this should probably not be integrated into the `develop` branch before PR #273.