### PR TITLE
(Tablacus) close before attempting to upgrade/uninstall

### DIFF
--- a/automatic/tablacus/tablacus.nuspec
+++ b/automatic/tablacus/tablacus.nuspec
@@ -35,6 +35,9 @@
 [Software Changelog](http://www.eonet.ne.jp/~gakana/tablacus/history/)
 [Package Changelog](https://github.com/AdmiringWorm/chocolatey-packages/blob/master/automatic/tablacus/Changelog.md)
     </releaseNotes>
+    <dependencies>
+      <dependency id="chocolatey-core.extension" version="1.3.4" />
+    </dependencies>
   </metadata>
   <files>
     <file src="legal\**" target="legal" />

--- a/automatic/tablacus/tools/chocolateyBeforeModify.ps1
+++ b/automatic/tablacus/tools/chocolateyBeforeModify.ps1
@@ -1,0 +1,5 @@
+﻿$ErrorActionPreference = 'Stop'
+$toolsPath = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
+$filter = [system.text.regularexpressions.regex]::escape((Join-Path $toolsPath "te"))
+
+Remove-Process -PathFilter $filter | Out-Null


### PR DESCRIPTION
Closes `te64.exe` and `te32.exe` before upgrade/uninstall.