### PR TITLE
fix(rethinkdb): typo causing lingering zip files after install

### DIFF
--- a/automatic/rethinkdb/tools/chocolateyinstall.ps1
+++ b/automatic/rethinkdb/tools/chocolateyinstall.ps1
@@ -9,4 +9,4 @@ $packageArgs = @{
 
 Get-ChocolateyUnzip @packageArgs
 
-Remove-Item "$ttolsDir\*.zip" -ea 0
+Remove-Item "$toolsDir\*.zip" -ea 0


### PR DESCRIPTION
Typo in the tools directory variable name means the rethinkdb archive is not deleted after install.