### PR TITLE
(qtcreator) Use "Qt Creator" instead of "QT Creator" in shortcut

### DIFF
--- a/automatic/qtcreator/tools/chocolateyinstall.ps1
+++ b/automatic/qtcreator/tools/chocolateyinstall.ps1
@@ -30,7 +30,7 @@ Get-ChildItem $packageArgs.destination -Include "*.exe" -Recurse | ForEach-Objec
 if ($qtCreator) {
   # Because chocolatey targets 4.0, we are able to use 'Programs' in the 'GetFolderPath'
   $programs = [System.Environment]::GetFolderPath("Programs")
-  Install-ChocolateyShortcut -shortcutFile "$programs\QT Creator.lnk" -targetPath $qtCreator
+  Install-ChocolateyShortcut -shortcutFile "$programs\Qt Creator.lnk" -targetPath $qtCreator
   Install-ChocolateyFileAssociation ".pro" $qtCreator
 } else {
   Write-Warning "Unable to find qtcreator executable, skipping start menu shortcut creation!"

--- a/automatic/qtcreator/tools/chocolateyuninstall.ps1
+++ b/automatic/qtcreator/tools/chocolateyuninstall.ps1
@@ -2,8 +2,8 @@
 
 # Remove the start menu shortcut
 $startMenu = [System.Environment]::GetFolderPath('Programs')
-if (Test-Path "$startMenu\QT Creator.lnk") {
-  Remove-Item -Force "$startMenu\QT Creator.lnk"
+if (Test-Path "$startMenu\Qt Creator.lnk") {
+  Remove-Item -Force "$startMenu\Qt Creator.lnk"
 }
 
 $hkey = "HKCR:\.pro"


### PR DESCRIPTION
i.e. a lower case "t" as the second letter, as is the
official spelling.

Request to change it is here:
https://community.chocolatey.org/packages/qtcreator#comment-5607038603