### PR TITLE
(authy-desktop) advertise product to current user for background service installations

### DIFF
--- a/automatic/authy-desktop/tools/chocolateyinstall.ps1
+++ b/automatic/authy-desktop/tools/chocolateyinstall.ps1
@@ -10,7 +10,7 @@ $packageArgs = @{
   checksumType   = ''
   checksum64     = '23b2505a2edd4d702b46307c3eadffa3105838a6c259cc66d52935c07f311c308f70218d7e061d08b331d0d7aeed7d9ee3b847ec70475d4d1b849c93f259f4f5'
   checksumType64 = 'sha512'
-  silentArgs     = '-s'
+  silentArgs     = '-s -ju'
   validExitCodes = @(0)
 }
 


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

This change will adjust the installation of the Authy Desktop to advertise the product to the current user.

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
<!-- Use fixes/fixed when referencing the issue -->

This fixes an issue when using the Chocolatey background service for installing this software.
The Authy Desktop is a per-user installation, when using the Chocolatey background service
the software is only installed for the `ChocolateyLocalAdmin` user, with the `/ju` MSI flag it will
get advertised to the user invoking the installation and be available for them as well.

## How Has this Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the script, etc. -->

This has been tested in our cooperate environment using Chocolatey for Business, using the
background service. A sandbox VM was used to test the change without using the background
service, the behaviour there is unchanged.

This change has also been tested using the `/jm` flag, while the Microsoft documentation
states that this will advertise the product machine wide, this didn't seem to work in practice
in my tests.
