### PR TITLE
qtcreator-cdbext: Update links

### DIFF
--- a/automatic/qtcreator-cdbext/qtcreator-cdbext.nuspec
+++ b/automatic/qtcreator-cdbext/qtcreator-cdbext.nuspec
@@ -8,14 +8,14 @@
     <owners>AdmiringWorm, michaelweghorn</owners>
     <title>Qt Creator CDB Extension</title>
     <authors>Qt Project</authors>
-    <projectUrl>http://wiki.qt.io/Qt_Creator</projectUrl>
+    <projectUrl>https://wiki.qt.io/Qt_Creator</projectUrl>
     <iconUrl>https://cdn.jsdelivr.net/gh/AdmiringWorm/chocolatey-packages@35eb3e49edb3411d779f64e57ef023abac8a3a06/icons/qtcreator.png</iconUrl>
     <copyright>© 2020 The Qt Company Ltd.</copyright>
-    <licenseUrl>http://code.qt.io/cgit/qt-creator/qt-creator.git/plain/LICENSE.GPL3-EXCEPT?h=4.1</licenseUrl>
+    <licenseUrl>https://code.qt.io/cgit/qt-creator/qt-creator.git/plain/LICENSE.GPL3-EXCEPT?h=4.1</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <projectSourceUrl>https://code.qt.io/cgit/qt-creator/qt-creator.git/tree/src/libs/qtcreatorcdbext/</projectSourceUrl>
     <docsUrl>https://wiki.qt.io/Qt_Creator_Windows_Debugging</docsUrl>
-    <mailingListUrl>http://lists.qt-project.org/mailman/listinfo/qt-creator/</mailingListUrl>
+    <mailingListUrl>https://lists.qt-project.org/mailman/listinfo/qt-creator</mailingListUrl>
     <bugTrackerUrl>https://bugreports.qt.io/browse/QTCREATORBUG</bugTrackerUrl>
     <tags>qtcreator-cdbext cdbext c++ qt ide qtcreator plugin</tags>
     <summary>CDB (Microsoft Console Debugger) extension for Qt Creator.</summary>
@@ -24,7 +24,7 @@
 
 The Debugging Tools for Windows (which include the CDB debugger) need to be installed separately by installing one of the components mentioned on [this Microsoft help page](https://docs.microsoft.com/en-us/windows-hardware/drivers/debugger/). (Chocolatey packages for different versions of the components are available.)
 ]]></description>
-    <releaseNotes>[Software Changelog](http://code.qt.io/cgit/qt-creator/qt-creator.git/plain/dist/changes-13.0.0.md)
+    <releaseNotes>[Software Changelog](https://code.qt.io/cgit/qt-creator/qt-creator.git/plain/dist/changelog/changes-13.0.0.md)
 [Package Changelog](https://github.com/AdmiringWorm/chocolatey-packages/blob/master/automatic/qtcreator-cdbext/Changelog.md)</releaseNotes>
     <dependencies>
       <dependency id="qtcreator" version="[13.0.0]" />

--- a/automatic/qtcreator-cdbext/update.ps1
+++ b/automatic/qtcreator-cdbext/update.ps1
@@ -22,7 +22,7 @@ function global:au_AfterUpdate {
   Update-Changelog -useIssueTitle
 
   $releaseNotes = @"
-[Software Changelog](http://code.qt.io/cgit/qt-creator/qt-creator.git/plain/dist/changes-$($Latest.RemoteVersion).md)
+[Software Changelog](https://code.qt.io/cgit/qt-creator/qt-creator.git/plain/dist/changelog/changes-$($Latest.RemoteVersion).md)
 [Package Changelog](https://github.com/AdmiringWorm/chocolatey-packages/blob/master/automatic/qtcreator-cdbext/Changelog.md)
 "@
 


### PR DESCRIPTION
* switch from "http://" to "https://" URLs
* update path to changelogs which changed with qt-creator commit [1] ("Install and ship change logs")

Without these changes, the initial submission
of Qt Creator CDB Extension 13.0.1 to Chocolatey
failed automated validation:

> qtcreator-cdbext has failed automated validation.
>
> # Requirements
>
> Requirements represent the minimum quality of a package that is
> acceptable. When a package version has failed requirements, the package
> version requires fixing and/or response by the maintainer. Provided a
> Requirement has flagged correctly, it must be fixed before the package
> version can be approved. The exact same version should be uploaded
> during moderation review.
>
> The MailingListUrl element in the nuspec file should be a valid Url.
> Please correct this [More...]
>
> # Guidelines
>
> Guidelines are strong suggestions that improve the quality of a package
> version. These are considered something to fix for next time to increase
> the quality of the package. Over time Guidelines can become
> Requirements. A package version can be approved without addressing
> Guideline comments but will reduce the quality of the package.
>
> In the ReleaseNotes element of the nuspec file a potentially invalid Url
> has been found. Recommendation is to fix this URL [More.]

[1] https://code.qt.io/cgit/qt-creator/qt-creator.git/commit/?id=b364cfde2375b2fa56b97e42346affecd2030080