### PR TITLE
qtcreator: Update links

### DIFF
--- a/automatic/qtcreator/qtcreator.nuspec
+++ b/automatic/qtcreator/qtcreator.nuspec
@@ -8,21 +8,21 @@
     <owners>AdmiringWorm</owners>
     <title>Qt Creator</title>
     <authors>Qt Project</authors>
-    <projectUrl>http://wiki.qt.io/Qt_Creator</projectUrl>
+    <projectUrl>https://wiki.qt.io/Qt_Creator</projectUrl>
     <iconUrl>https://cdn.jsdelivr.net/gh/AdmiringWorm/chocolatey-packages@35eb3e49edb3411d779f64e57ef023abac8a3a06/icons/qtcreator.png</iconUrl>
     <copyright>© 2016 The Qt Company Ltd.</copyright>
-    <licenseUrl>http://code.qt.io/cgit/qt-creator/qt-creator.git/plain/LICENSE.GPL3-EXCEPT?h=4.1</licenseUrl>
+    <licenseUrl>https://code.qt.io/cgit/qt-creator/qt-creator.git/plain/LICENSE.GPL3-EXCEPT?h=4.1</licenseUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
-    <projectSourceUrl>http://code.qt.io/cgit/qt-creator/qt-creator.git/</projectSourceUrl>
+    <projectSourceUrl>https://code.qt.io/cgit/qt-creator/qt-creator.git/</projectSourceUrl>
     <docsUrl>https://doc.qt.io/qtcreator/</docsUrl>
-    <mailingListUrl>http://lists.qt-project.org/mailman/listinfo/qt-creator/</mailingListUrl>
+    <mailingListUrl>https://lists.qt-project.org/mailman/listinfo/qt-creator</mailingListUrl>
     <bugTrackerUrl>https://bugreports.qt.io/browse/QTCREATORBUG</bugTrackerUrl>
     <tags>c++ qt ide qtcreator admin</tags>
     <summary>Cross-platform IDE for easy creation of connected devices, UIs and applications.</summary>
     <!-- Do not touch the description here in the nuspec file. Description is imported during update from the Readme.md file -->
     <description><![CDATA[Qt Creator provides a cross-platform, complete integrated development environment (IDE) for application developers to create applications for multiple desktop and mobile device platforms, such as Android and iOS.
 ]]></description>
-    <releaseNotes>[Software Changelog](http://code.qt.io/cgit/qt-creator/qt-creator.git/plain/dist/changes-5.0.0.md)
+    <releaseNotes>[Software Changelog](https://code.qt.io/cgit/qt-creator/qt-creator.git/plain/dist/changelog/changes-13.0.0.md)
 [Package Changelog](https://github.com/AdmiringWorm/chocolatey-packages/blob/master/automatic/qtcreator/Changelog.md)</releaseNotes>
     <dependencies>
       <dependency id="vcredist2017" version="14.16.27027.20190415" />

--- a/automatic/qtcreator/update.ps1
+++ b/automatic/qtcreator/update.ps1
@@ -28,7 +28,7 @@ function global:au_AfterUpdate {
   Update-Changelog -useIssueTitle
 
   $releaseNotes = @"
-[Software Changelog](http://code.qt.io/cgit/qt-creator/qt-creator.git/plain/dist/changes-$($Latest.RemoteVersion).md)
+[Software Changelog](https://code.qt.io/cgit/qt-creator/qt-creator.git/plain/dist/changelog/changes-$($Latest.RemoteVersion).md)
 [Package Changelog](https://github.com/AdmiringWorm/chocolatey-packages/blob/master/automatic/qtcreator/Changelog.md)
 "@
 


### PR DESCRIPTION
Just like [1] does for qtcreator-cdbext, update
links for qtcreator as well:

* switch from "http://" to "https://" URLs
* update path to changelogs which changed with qt-creator commit [2] ("Install and ship change logs")

[1] https://github.com/AdmiringWorm/chocolatey-packages/pull/410
[2] https://code.qt.io/cgit/qt-creator/qt-creator.git/commit/?id=b364cfde2375b2fa56b97e42346affecd2030080