### PR TITLE
qtcreator-cdbext: Make update work

### DIFF
--- a/automatic/qtcreator-cdbext/update.ps1
+++ b/automatic/qtcreator-cdbext/update.ps1
@@ -52,4 +52,4 @@ function global:au_GetLatest {
   }
 }
 
-update
+update -ChecksumFor none -NoCheckUrl


### PR DESCRIPTION
In the update script for the qtcreator-cdbext package, add the `-ChecksumFor none -NoCheckUrl` args to the `update` call, which are already used for the qtcreator package as well.

Otherwise, the update (to current version 15.0) fails like this:

    PS C:\tools\cygwin\home\user\development\git\chocolatey-packages> .\update_all.ps1 -Name qtcreator-cdbext
    Updating 1 automatic packages at 2024-12-21 22:11:46
    Push is disabled
    NoCheckChocoVersion is disabled
       [1/1] qtcreator-cdbext ERROR:
         URL syntax is invalid:qtcreatorcdbext.7z (2.52s)