### PR TITLE
(CI) update upload artifact version

### DIFF
--- a/.github/workflows/package-pusher.yml
+++ b/.github/workflows/package-pusher.yml
@@ -62,7 +62,7 @@ jobs:
         shell: powershell
       - name: Upload artifacts
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: artifacts
           path: |

--- a/.github/workflows/package-tests.yml
+++ b/.github/workflows/package-tests.yml
@@ -59,7 +59,7 @@ jobs:
           git diff --cached > unsaved_changes.patch
       - name: Upload artifacts
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: artifacts-${{ matrix.os }}
           path: |

--- a/.github/workflows/package-updater.yml
+++ b/.github/workflows/package-updater.yml
@@ -78,7 +78,7 @@ jobs:
         shell: powershell
       - name: Upload artifacts
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: artifacts
           path: |


### PR DESCRIPTION
As per the GitHub community discussion below, v3 of the download and upload actions are deprecated and no longer work. https://github.com/orgs/community/discussions/142581

Tested on my fork, and it fixes the error that all of the jobs are failing with.
https://github.com/TheCakeIsNaOH/chocolatey-packages-AdmiringWorm/actions/runs/15200759014/job/42754340834

I don't know if there are any other issues remaining, but this should at least get past the part they are currently failing at.