### PR TITLE
(lunacy) Normalize version before returning

### DIFF
--- a/automatic/lunacy/update.ps1
+++ b/automatic/lunacy/update.ps1
@@ -32,7 +32,7 @@ function global:au_GetLatest {
 
   return @{
     URL32          = $url32
-    Version        = $version
+    Version        = Get-NormalizedVersion $version
     ChecksumType32 = 'sha512'
   }
 }


### PR DESCRIPTION
- Call GetormalizedVersion on the gathered version string before returning the Version field
- Ensure the Version field is always normalized to prevent downstream format inconsistencies
- Standardize version handling for update checks